### PR TITLE
fix(typescript): fix build directory structure to resolve npm import

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "target": "es5",
     "typeRoots": ["./node_modules/@types", "./types"]
   },
-  "include": ["src/**/*", "test/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- The build from the previous publish caused another level of folder depth in the `dist` folder so the npm module wouldn't work. This PR resolves that issue.