### PR TITLE
Add isCandleInterval type guard

### DIFF
--- a/API.md
+++ b/API.md
@@ -70,6 +70,7 @@
     -   [isWebSocketUnauthenticatedSubscription](#iswebsocketunauthenticatedsubscription)
     -   [isWebSocketCandlesSubscription](#iswebsocketcandlessubscription)
     -   [isWebSocketLooseSubscription](#iswebsocketloosesubscription)
+    -   [isCandleInterval](#iscandleinterval)
 -   [ECDSA Signatures](#ecdsa-signatures)
     -   [MessageSigner](#messagesigner)
 -   [Misc Types & Utilities](#misc-types--utilities)
@@ -1674,6 +1675,20 @@ This should be used lightly.
 #### Properties
 
 -   `subscription` **any** The subscription to check
+
+Returns **any** 
+
+### isCandleInterval
+
+A type guard which checks if a string is a valid candle interval.
+
+#### Parameters
+
+-   `value` **any** 
+
+#### Properties
+
+-   `value` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The subscription to check
 
 Returns **any** 
 

--- a/documentation.yaml
+++ b/documentation.yaml
@@ -99,6 +99,7 @@ toc:
       - isWebSocketUnauthenticatedSubscription
       - isWebSocketCandlesSubscription
       - isWebSocketLooseSubscription
+      - isCandleInterval
   - name: ECDSA Signatures
     children:
       - MessageSigner

--- a/src/client/webSocket/index.ts
+++ b/src/client/webSocket/index.ts
@@ -391,18 +391,10 @@ export class WebSocketClient {
   }
 }
 
-function isAuthenticatedSubscription(
-  subscription: types.WebSocketRequestSubscription,
-): subscription is types.AuthTokenWebSocketRequestAuthenticatedSubscription {
-  return Object.keys(
-    types.WebSocketRequestAuthenticatedSubscriptionName,
-  ).includes(subscription.name);
-}
-
 // We use this instead of the other type guards to account for unhandled subscription
 // types
 function isPublicSubscription(
   subscription: types.WebSocketRequestSubscription,
 ): boolean {
-  return !isAuthenticatedSubscription(subscription);
+  return !isWebSocketAuthenticatedSubscription(subscription);
 }

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,0 +1,12 @@
+import { CandleInterval } from './enums';
+
+const intervals = Object.keys(CandleInterval);
+
+/**
+ * A type guard which checks if a string is a valid candle interval.
+ *
+ * @property {string} value - The subscription to check
+ */
+export function isCandleInterval(value: unknown): value is CandleInterval {
+  return intervals.includes(value as string);
+}

--- a/src/types/webSocket/request.ts
+++ b/src/types/webSocket/request.ts
@@ -1,22 +1,13 @@
 import * as enums from '../enums';
 import { AugmentedOptional, AugmentedRequired, Expand } from '../utils';
-
-export const WebSocketRequestAuthenticatedSubscriptionName = {
-  balances: 'balances',
-  orders: 'orders',
-} as const;
-
-export const WebSocketRequestUnauthenticatedSubscriptionName = {
-  candles: 'candles',
-  l1orderbook: 'l1orderbook',
-  l2orderbook: 'l2orderbook',
-  tickers: 'tickers',
-  trades: 'trades',
-} as const;
+import {
+  WEBSOCKET_AUTHENTICATED_SUBSCRIPTIONS,
+  WEBSOCKET_UNAUTHENTICATED_SUBSCRIPTIONS,
+} from './constants';
 
 export type WebSocketRequestSubscriptionName =
-  | keyof typeof WebSocketRequestUnauthenticatedSubscriptionName
-  | keyof typeof WebSocketRequestAuthenticatedSubscriptionName;
+  | typeof WEBSOCKET_AUTHENTICATED_SUBSCRIPTIONS[number]
+  | typeof WEBSOCKET_UNAUTHENTICATED_SUBSCRIPTIONS[number];
 
 export type WebSocketRequestBalancesSubscription = {
   name: 'balances';


### PR DESCRIPTION
Since candle interval is generally strictly typed and `string` can not be used when it is expected, this type guard makes it possible to check to confirm a given string is a valid candle interval value.

