### PR TITLE
feat: add not found status to cancel orders response

### DIFF
--- a/src/types/enums/response.ts
+++ b/src/types/enums/response.ts
@@ -105,18 +105,30 @@ export type FillAction = (typeof FillAction)[keyof typeof FillAction];
  */
 export const OrderStatus = Object.freeze({
   /**
-   * @internal
+   * Stop order exists on the order book
    */
-  new: 'new',
+  active: 'active',
+  /**
+   * Limit order was canceled prior to execution completion but may be partially filled
+   */
+  canceled: 'canceled',
   expired: 'expired',
+  /**
+   * Limit order is completely filled and is no longer on the book; market order was filled
+   */
+  filled: 'filled',
   /**
    * Conditional and trailing stop orders that have not yet entered the active state
    */
   inactive: 'inactive',
   /**
-   * Stop order exists on the order book
+   * @internal
    */
-  active: 'active',
+  new: 'new',
+  /*
+   * Order ID to cancel was not found
+   */
+  notFound: 'notFound',
   /**
    * Limit order exists on the order book
    */
@@ -125,14 +137,6 @@ export const OrderStatus = Object.freeze({
    * Limit order has completed fills but has remaining open quantity
    */
   partiallyFilled: 'partiallyFilled',
-  /**
-   * Limit order is completely filled and is no longer on the book; market order was filled
-   */
-  filled: 'filled',
-  /**
-   * Limit order was canceled prior to execution completion but may be partially filled
-   */
-  canceled: 'canceled',
   /**
    * Order was rejected by the trading engine
    */

--- a/src/types/rest/endpoints/CancelOrders.ts
+++ b/src/types/rest/endpoints/CancelOrders.ts
@@ -125,6 +125,12 @@ export interface IDEXCanceledOrder {
    * within the cancel object when cancelled by any of your requests.
    */
   readonly clientOrderId?: string;
+  /**
+   * Current order status, either canceled or notFound if provided ID was not on the books
+   *
+   * @see enum {@link OrderStatus}
+   */
+  status: Extract<idex.OrderStatus, 'canceled' | 'notFound'>;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new order statuses: `canceled`, `filled`, and `notFound`.
  - Updated descriptions for order statuses to reflect new meanings and usage.

- **Improvements**
  - Added `status` property to cancelled orders, indicating whether the order is `canceled` or `notFound`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->