### PR TITLE
fix(buy/sell panel): reducing standing orders applied incorrectly (2)

### DIFF
--- a/src/tests/orderbook/buySellPanelEstimateUtils/stepThroughMatchingLoopQuantities.test.ts
+++ b/src/tests/orderbook/buySellPanelEstimateUtils/stepThroughMatchingLoopQuantities.test.ts
@@ -2,15 +2,15 @@ import * as chai from 'chai';
 
 import { decimalToPip } from '#pipmath';
 
-import { stepThroughMatchingLoopQuantities } from '../../../orderbook/buySellPanelEstimateUtils';
+import { stepThroughMatchingLoopQuantities } from '#orderbook/buySellPanelEstimateUtils';
 
+import type { MakerAndReducingStandingOrderQuantityAndPrices } from '#orderbook/buySellPanelEstimateUtils';
+import type * as orderbook from '#orderbook/index';
 import type { OrderSide } from '#types/enums/request';
-import type { MakerAndReducingStandingOrderQuantityAndPrices } from '../../../orderbook/buySellPanelEstimateUtils';
-import type * as orderbookTypes from '../../../orderbook/types';
 
 const { expect } = chai;
 
-const defaultLeverageParameters: orderbookTypes.LeverageParametersBigInt = {
+const defaultLeverageParameters: orderbook.LeverageParametersBigInt = {
   initialMarginFraction: decimalToPip('0.03'),
   incrementalInitialMarginFraction: decimalToPip('0.01'),
 
@@ -23,7 +23,7 @@ const defaultLeverageParameters: orderbookTypes.LeverageParametersBigInt = {
 
 const fooMarketSymbol = 'FOO-USD';
 
-function makeAPosition(quantity: string): orderbookTypes.Position {
+function makeAPosition(quantity: string): orderbook.Position {
   return {
     market: fooMarketSymbol,
     quantity: decimalToPip(quantity),

--- a/src/tests/orderbook/quantities/calculateGrossFillQuantities.test.ts
+++ b/src/tests/orderbook/quantities/calculateGrossFillQuantities.test.ts
@@ -5,14 +5,12 @@ import { decimalToPip } from '#pipmath';
 import * as orderbook from '#orderbook/index';
 import { OrderSide } from '#types/enums/request';
 
-import type * as orderbookTypes from '../../../orderbook/types';
-
 const { expect } = chai;
 
 describe('orderbook/quantities', () => {
   describe('calculateGrossFillQuantities', () => {
     const runScenario = (args: {
-      makerSideOrders: orderbookTypes.PriceAndSize[];
+      makerSideOrders: orderbook.PriceAndSize[];
       takerOrder: {
         side: OrderSide;
         quantity: string;
@@ -43,7 +41,7 @@ describe('orderbook/quantities', () => {
     };
 
     it('should succeed', () => {
-      const sellSideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const sellSideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') }, // 1 quote
         { price: decimalToPip('2'), size: decimalToPip('10') }, // 20 quote
         { price: decimalToPip('3'), size: decimalToPip('100') }, // 300 quote
@@ -111,7 +109,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should succeed for a taker quantity specified in quote', () => {
-      const sellSideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const sellSideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') }, // 1 quote
         { price: decimalToPip('2'), size: decimalToPip('10') }, // 20 quote
         { price: decimalToPip('3'), size: decimalToPip('100') }, // 300 quote
@@ -179,7 +177,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should support multiple orders per price level', () => {
-      const sellSideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const sellSideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') },
         { price: decimalToPip('1'), size: decimalToPip('1') },
         { price: decimalToPip('2'), size: decimalToPip('1') },
@@ -228,7 +226,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should limit by price (buy)', () => {
-      const sellSideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const sellSideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') }, // 1 quote
         { price: decimalToPip('2'), size: decimalToPip('1') }, // 2 quote
         { price: decimalToPip('3'), size: decimalToPip('1') }, // 3 quote
@@ -247,7 +245,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should limit by price (sell)', () => {
-      const buySideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const buySideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('3'), size: decimalToPip('1') }, // 3 quote
         { price: decimalToPip('2'), size: decimalToPip('1') }, // 2 quote
         { price: decimalToPip('1'), size: decimalToPip('1') }, // 1 quote
@@ -266,7 +264,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should return zero if the limit price does not cross the spread (buy)', () => {
-      const sellSideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const sellSideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') },
       ];
       runScenario({
@@ -283,7 +281,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should return zero if the limit price does not cross the spread (sell)', () => {
-      const buySideMakerOrders: orderbookTypes.PriceAndSize[] = [
+      const buySideMakerOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('1'), size: decimalToPip('1') },
       ];
       runScenario({
@@ -300,7 +298,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should support double-pip precision', () => {
-      const makerSideOrders: orderbookTypes.PriceAndSize[] = [
+      const makerSideOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('3'), size: decimalToPip('1') },
       ];
 
@@ -334,7 +332,7 @@ describe('orderbook/quantities', () => {
     });
 
     it('should support double-pip precision (taker quantity specified in quote)', () => {
-      const makerSideOrders: orderbookTypes.PriceAndSize[] = [
+      const makerSideOrders: orderbook.PriceAndSize[] = [
         { price: decimalToPip('3'), size: decimalToPip('1') },
       ];
 

--- a/src/tests/orderbook/quantities/calculateInitialMarginFractionWithOverride.test.ts
+++ b/src/tests/orderbook/quantities/calculateInitialMarginFractionWithOverride.test.ts
@@ -4,11 +4,9 @@ import { decimalToPip } from '#pipmath';
 
 import * as orderbook from '#orderbook/index';
 
-import type * as orderbookTypes from '../../../orderbook/types';
-
 const { expect } = chai;
 
-const defaultLeverageParameters: orderbookTypes.LeverageParametersBigInt = {
+const defaultLeverageParameters: orderbook.LeverageParametersBigInt = {
   initialMarginFraction: decimalToPip('0.03'),
   incrementalInitialMarginFraction: decimalToPip('0.01'),
   basePositionSize: decimalToPip('1000'),

--- a/src/tests/orderbook/quantities/calculateMaximumMakerOrderSizeForAvailableCollateral.test.ts
+++ b/src/tests/orderbook/quantities/calculateMaximumMakerOrderSizeForAvailableCollateral.test.ts
@@ -4,11 +4,9 @@ import { decimalToPip, multiplyPips } from '#pipmath';
 
 import * as orderbook from '#orderbook/index';
 
-import type * as orderbookTypes from '../../../orderbook/types';
-
 const { expect } = chai;
 
-const defaultLeverageParameters: orderbookTypes.LeverageParametersBigInt = {
+const defaultLeverageParameters: orderbook.LeverageParametersBigInt = {
   initialMarginFraction: decimalToPip('0.1'),
   incrementalInitialMarginFraction: decimalToPip('0.02'),
   basePositionSize: decimalToPip('5'),

--- a/src/tests/orderbook/quantities/determineMaximumReduceOnlyQuantityAvailableAtPriceLevel.test.ts
+++ b/src/tests/orderbook/quantities/determineMaximumReduceOnlyQuantityAvailableAtPriceLevel.test.ts
@@ -4,9 +4,8 @@ import { decimalToPip, pipToDecimal } from '#pipmath';
 
 import * as orderbook from '#orderbook/index';
 
+import type { OrderSide } from '#types/enums/request';
 import type { IDEXPosition } from '#types/rest/endpoints/index';
-import type * as orderbookTypes from '../../../orderbook/types';
-import type { OrderSide } from '../../../types/enums/request';
 
 const { expect } = chai;
 
@@ -41,7 +40,7 @@ function makeAStandingOrder(args: {
   side: OrderSide;
   quantity: string;
   price: string;
-}): orderbookTypes.StandingOrder {
+}): orderbook.StandingOrder {
   return {
     market: args.marketSymbol,
     side: args.side,


### PR DESCRIPTION
- Reducing standing orders that are in total smaller than the position size were applied at the start of the reduction of the position instead of the end (closer to position closure)
- Increase/reduction in held funds did not carry over between iterations of matching loop