### PR TITLE
fix(buy/sell panel): maker quantities can cross the spread

### DIFF
--- a/src/orderbook/quantities.ts
+++ b/src/orderbook/quantities.ts
@@ -427,7 +427,8 @@ export function calculateBuySellPanelEstimate(
         });
         if (cost > BigInt(0)) {
           return makeReturnValue({
-            ...calculateMakerQtys(),
+            makerBaseQuantity: BigInt(0),
+            makerQuoteQuantity: BigInt(0),
             takerBaseQuantity: additionalPositionQty,
             takerQuoteQuantity: additionalPositionCostBasis,
           });
@@ -499,7 +500,8 @@ export function calculateBuySellPanelEstimate(
         desiredTradeQuoteQuantity === absBigInt(additionalPositionCostBasis))
     ) {
       return makeReturnValue({
-        ...calculateMakerQtys(),
+        makerBaseQuantity: BigInt(0),
+        makerQuoteQuantity: BigInt(0),
         takerBaseQuantity: additionalPositionQty,
         takerQuoteQuantity: additionalPositionCostBasis,
       });


### PR DESCRIPTION
In some situations, incremental IMR thresholds limit the amount of collateral that can be converted into a taker qty. The remaining collateral may not be converted into a maker qty because it would cross the spread.